### PR TITLE
Add ebook source note.

### DIFF
--- a/README-downloads.rst
+++ b/README-downloads.rst
@@ -1,0 +1,6 @@
+The epub source and downloads are taken from files posted on mobileread by user HarryT. They will not be in sync with the files from Project Gutenberg in this archive.
+
+http://www.mobileread.com/forums/showthread.php?t=73836
+
+
+


### PR DESCRIPTION
Should always provide as much information as possible about the source of ebook files.
